### PR TITLE
import deprecated functions from Base

### DIFF
--- a/src/Combinatorics.jl
+++ b/src/Combinatorics.jl
@@ -4,6 +4,14 @@ using Compat, Polynomials, Iterators
 
 import Base: start, next, done, length, eltype
 
+#These 8 functions were removed from Julia 0.5 as part of JuliaLang/julia#13897,
+#so check if it's necessary to import them to overload the stub methods left in
+#Base.
+if isdefined(Base, :combinations)
+    import Base: combinations, partitions, prevprod, levicivita, nthperm,
+                 nthperm!, parity, permutations
+end
+
 include("numbers.jl")
 include("factorials.jl")
 include("combinations.jl")

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -1,9 +1,6 @@
 using Combinatorics
 using Base.Test
 
-import Combinatorics: combinations
-
-
 @test collect(combinations([])) == []
 @test collect(combinations(['a', 'b', 'c'])) == Any[['a'],['b'],['c'],['a','b'],['a','c'],['b','c'],['a','b','c']]
 

--- a/test/partitions.jl
+++ b/test/partitions.jl
@@ -1,6 +1,5 @@
 using Combinatorics
 using Base.Test
-import Combinatorics: partitions, prevprod
 
 @test collect(partitions(4)) ==  Any[[4], [3,1], [2,2], [2,1,1], [1,1,1,1]]
 @test collect(partitions(8,3)) == Any[[6,1,1], [5,2,1], [4,3,1], [4,2,2], [3,3,2]]

--- a/test/permutations.jl
+++ b/test/permutations.jl
@@ -1,8 +1,6 @@
 using Combinatorics
 using Base.Test
 
-import Combinatorics: levicivita, nthperm, nthperm!, parity, permutations
-
 # permutations
 @test collect(permutations("abc")) == Any[['a','b','c'],['a','c','b'],['b','a','c'],
                                           ['b','c','a'],['c','a','b'],['c','b','a']]


### PR DESCRIPTION
On 0.5, the 8 functions excised from Base are still defined, as they
have methods that print the error to use Combinatorics.jl.

Ref:
https://github.com/JuliaLang/julia/pull/13897#issuecomment-155995516