### PR TITLE
The tests for latest master work on 0.4, except for the method overwrite warnings

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.5-
+julia 0.4
 Polynomials
 Iterators


### PR DESCRIPTION
Doing `git checkout master` on 0.4 gives passing tests (but, of course, with the method overwrite warnings). 