### PR TITLE
add Compat back to REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.4
 Polynomials
 Iterators
+Compat


### PR DESCRIPTION
it is still used by the package so it still needs to be required unless all uses of it are removed