### PR TITLE
Check if Julia version is post-combinatorics removal

### DIFF
--- a/src/Combinatorics.jl
+++ b/src/Combinatorics.jl
@@ -8,8 +8,8 @@ import Base: start, next, done, length, eltype
 
 #These 8 functions were removed from Julia 0.5 as part of JuliaLang/julia#13897,
 #so check if it's necessary to import them to overload the stub methods left in
-#Base.
-if isdefined(Base, :combinations)
+#Base. Only do this if on a version of Julia post-combinatorics removal.
+if isdefined(Base, :combinations) && VERSION >= v"0.5.0-dev+1204"
     import Base: combinations, partitions, prevprod, levicivita, nthperm,
                  nthperm!, parity, permutations
 end


### PR DESCRIPTION
This should fix #26 as almost all overwrite warnings are suppressed except those for `factorial`. 